### PR TITLE
Gather documents filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ The plugin has some configuration options. These can be set by adding a config f
 ```json
 {
   "tool": true,
-  "types": ["article", "page"]
+  "types": ["article", "page"],
+  "filter": "_type != 'product'"
 }
 ```
 
@@ -63,6 +64,7 @@ Options:
 
 - `tool` (boolean, default: true) – Set whether the Migration Tool is enabled.
 - `types` (Array[String], default: []) – Set which Schema Types the Migration Action should be enabled in.
+- `filter` (String, default: undefined) - Set a predicate for documents when gathering dependencies.
 
 ### 3. Authentication Key
 
@@ -75,7 +77,6 @@ You can [create API tokens in manage](https://sanity.io/manage)
 ### 4. CORS origins
 
 If you want to duplicate data across different projects, you need to enable CORS for the different hosts. This allows different projects to connect to each other through the project API. CORS origins configuration can be found in your project page, under the API tab.
-
 
 ## Importing the Document Action
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "@sanity/icons": "^1.2.5",
+    "@sanity/mutator": "^2.13.0",
     "@sanity/ui": "^0.36.15",
     "async": "^3.2.1",
     "dset": "^3.1.0",
@@ -47,8 +48,7 @@
     "sanipack": "^2.1.0"
   },
   "peerDependencies": {
-    "react": "^17.0.0",
-    "@sanity/mutator": "^2.13.0"
+    "react": "^17.0.0"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/cross-dataset-duplicator/issues"

--- a/src/helpers/getDocumentsInArray.ts
+++ b/src/helpers/getDocumentsInArray.ts
@@ -1,5 +1,7 @@
-import {extract} from '@sanity/mutator'
-import {SanityDocument} from '../types'
+import { extract } from '@sanity/mutator'
+import { SanityDocument } from '../types'
+
+import config from 'config:@sanity/cross-dataset-duplicator'
 
 // Recursively fetch Documents from an array of _id's and their references
 // Heavy use of Set is to avoid recursively querying for id's already in the payload
@@ -12,7 +14,8 @@ export async function getDocumentsInArray(
   const collection = []
 
   // Find initial docs
-  const query = `*[_id in $fetchIds]${projection ?? ``}`
+  const filter = ['_id in $fetchIds', config.filter].filter(Boolean).join(' && ')
+  const query = `*[${filter}]${projection ?? ``}`
   const data: SanityDocument[] = await client.fetch(query, {
     fetchIds: fetchIds ?? [],
   })
@@ -22,7 +25,7 @@ export async function getDocumentsInArray(
   }
 
   const localCurrentIds = currentIds ?? new Set()
-  
+
   // Find new ids in the returned data
   // Unless we started with an empty set, get the _ids from the data
   const newDataIds: Set<string> = new Set(
@@ -70,7 +73,7 @@ export async function getDocumentsInArray(
     }
 
     return [...acc, cur]
-  }, []) 
+  }, [])
 
   return uniqueCollection
 }


### PR DESCRIPTION
## Problem

Using the cross-dataset-duplicator action on documents whose dependency tree is especially large (because of some unfortunate dataset architecture with big circular dependencies) can cause the tool to be rate limited when it is trying to gather dependencies.

## Solution

It would be nice to be able to optionally provide a predicate filter that would exclude certain types of documents to be considered when gathering references.

## Result

The changes is this PR allow for developer to set a `filter` option in the plugin config JSON. The dependencies of any document that does not pass the predicate will not be explored of fetched when gathering dependencies.