### PR TITLE
Ability to seed `docs` with inbound references

### DIFF
--- a/src/components/CrossDatasetDuplicator.tsx
+++ b/src/components/CrossDatasetDuplicator.tsx
@@ -3,7 +3,7 @@ import {useSecrets, SettingsView} from 'sanity-secrets'
 import {ThemeProvider, Flex, Box, Spinner} from '@sanity/ui'
 
 import DuplicatorQuery from './DuplicatorQuery'
-import DuplicatorTool from './DuplicatorTool'
+import {DuplicatorToolWrapper} from './DuplicatorTool'
 import ResetSecret from './ResetSecret'
 import Feedback from './Feedback'
 import {SanityDocument} from '../types'
@@ -94,7 +94,7 @@ export default function CrossDatasetDuplicator(props: CrossDatasetDuplicatorProp
 
   return (
     <ThemeProvider>
-      <DuplicatorTool docs={docs} token={secrets?.bearerToken} />
+      <DuplicatorToolWrapper docs={docs} token={secrets?.bearerToken} />
     </ThemeProvider>
   )
 }


### PR DESCRIPTION
## Problem

Currently it is possible to gather and thus duplicate all documents that the source document depends on, but the same is not true for documents that depend on the source document. For teams that rely on the cross-dataset-duplicator as the primary means to migrate content across datasets, it feels like it would be convenient to be able to "gather all documents (and any dependencies thereof) that reference this source document".

## Solution

Wrap the `DuplicatorTool` with a UI that allows that allows the user to toggle whether they want to seed `docs` with the source document (original and now default behaviour) or a list of documents that reference the source document (if there are any).

## Considerations

The change here defaults to the existing behaviour and the interface of `DuplicatorTool` is unchanged so it should be backwards compatible with previous versions but it could also be behind a flag in the config.

Perhaps something like:
```
allow: ["inbound", "outbound"]
```

