### PR TITLE
fix: update useClient to use api, remove React default imports

### DIFF
--- a/src/actions/DuplicateToAction.tsx
+++ b/src/actions/DuplicateToAction.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react'
+import {useState} from 'react'
 import {LaunchIcon} from '@sanity/icons'
 import {DocumentActionProps} from 'sanity'
 

--- a/src/components/CrossDatasetDuplicator.tsx
+++ b/src/components/CrossDatasetDuplicator.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react'
+import {useEffect, useState} from 'react'
 import {useSecrets, SettingsView} from '@sanity/studio-secrets'
 import {Flex, Box, Spinner} from '@sanity/ui'
 import {SanityDocument} from 'sanity'

--- a/src/components/CrossDatasetDuplicatorAction.tsx
+++ b/src/components/CrossDatasetDuplicatorAction.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import {CrossDatasetDuplicatorActionProps} from '../types'
 
 import CrossDatasetDuplicator from './CrossDatasetDuplicator'

--- a/src/components/CrossDatasetDuplicatorTool.tsx
+++ b/src/components/CrossDatasetDuplicatorTool.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import {SanityDocument, Tool} from 'sanity'
 
 import CrossDatasetDuplicator from './CrossDatasetDuplicator'

--- a/src/components/DuplicatorQuery.tsx
+++ b/src/components/DuplicatorQuery.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react'
+import {useEffect, useState} from 'react'
 import {Button, Stack, Box, Label, Text, Card, Flex, Grid, Container, TextInput} from '@sanity/ui'
 import {useSchema, useClient, SanityDocument} from 'sanity'
 

--- a/src/components/DuplicatorWrapper.tsx
+++ b/src/components/DuplicatorWrapper.tsx
@@ -1,9 +1,10 @@
-import React, {useState, useEffect} from 'react'
+import {useState, useEffect} from 'react'
 import {Grid, Card, Container, Button} from '@sanity/ui'
 import {SanityDocument, useClient} from 'sanity'
 
 import type {DuplicatorProps} from './Duplicator'
 import Duplicator from './Duplicator'
+import {clientConfig} from '../helpers/clientConfig'
 
 export default function DuplicatorWrapper(props: DuplicatorProps) {
   const {docs, token, pluginConfig} = props
@@ -14,7 +15,7 @@ export default function DuplicatorWrapper(props: DuplicatorProps) {
   const [mode, setMode] = useState<'inbound' | 'outbound'>(
     follow.length === 1 ? follow[0] : `outbound`
   )
-  const client = useClient()
+  const client = useClient(clientConfig)
 
   // "Inbound" will start with all documents that reference the first one
   // And then you can gather "Outbound" references thereafter

--- a/src/components/ResetSecret.tsx
+++ b/src/components/ResetSecret.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import {useCallback} from 'react'
 import {useClient} from 'sanity'
 import {Button, Flex} from '@sanity/ui'
 
@@ -8,7 +8,7 @@ import {SECRET_NAMESPACE} from '../helpers/constants'
 export default function ResetSecret() {
   const client = useClient(clientConfig)
 
-  const handleClick = React.useCallback(() => {
+  const handleClick = useCallback(() => {
     client.delete({query: `*[_id == "secrets.${SECRET_NAMESPACE}"]`})
   }, [client])
 

--- a/src/components/SelectButtons.tsx
+++ b/src/components/SelectButtons.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from 'react'
+import {useState, useEffect} from 'react'
 import {Button, Card, Flex} from '@sanity/ui'
 
 import {PayloadItem} from './Duplicator'

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import {Box, Text, Badge, Tooltip} from '@sanity/ui'
 import type {BadgeTone} from '@sanity/ui'
 

--- a/src/context/ConfigProvider.tsx
+++ b/src/context/ConfigProvider.tsx
@@ -1,4 +1,4 @@
-import React, {useContext} from 'react'
+import {useContext} from 'react'
 import {createContext} from 'react'
 import {LayoutProps} from 'sanity'
 


### PR DESCRIPTION
Removes the console warning for using `useClient` without specifying `apiVersion`