### PR TITLE
Feat/max depth references

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,10 @@ The plugin has some configuration options. These can be set by adding a config f
       tool: true,
       filter: '_type != "product"',
       follow: [],
-      referenceMaxDepth: 2, // Number of documents deep to follow,  0 represents the current document only
-      referenceMaxDepthAssetsOnly: true // If true, only gather image and file assests.  'referenceMaxDepth' must be set.
+      reference: {
+        maxDepth: 1, // Number of documents deep to follow.  0 represents the current document only.
+        assetsOnly: true, // If true, only gather image and file assests.  'referenceMaxDepth' must be set.
+      },
     })
   ]
  })

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ The plugin has some configuration options. These can be set by adding a config f
 - `types` (Array[String], default: []) – Set which Schema Types the Migration Action should be enabled in.
 - `filter` (String, default: undefined) - Set a predicate for documents when gathering dependencies.
 - `follow` (("inbound" | "outbound")[], default: []) – Add buttons to allow the user to begin with just the existing document or first fetch all inbound references.
-- `referenceMaxDepth` (Number, default: undefined) - The level of documents deep to follow, `0` represents the current document only. Must be a positive number. This is useful for when when gathering references returns a large number of references or when you want to be a bit more intentional about the which reference you gather.
-- `referenceMaxDepthAssetsOnly`: (boolean) - If true, only gather image and file assests. The 'referenceMaxDepth' option must be set for this to work.
+- `reference.maxDepth` (Number, default: undefined) - The level of documents deep to follow, `0` represents the current document only. Must be a positive number. This is useful for when when gathering references returns a large number of references or when you want to be a bit more intentional about the which reference you gather.
+- `reference.assetsOnly`: (boolean) - If true, only gather image and file assests. The 'referenceMaxDepth' option must be set for this to work.
 
 #### Action Options
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ The plugin has some configuration options. These can be set by adding a config f
       // Optional settings
       tool: true,
       filter: '_type != "product"',
-      follow: []
+      follow: [],
+      referenceMaxDepth: 2, // Number of documents deep to follow,  0 represents the current document only
+      referenceMaxDepthAssetsOnly: true // If true, only gather image and file assests.  'referenceMaxDepth' must be set.
     })
   ]
  })
@@ -78,6 +80,8 @@ The plugin has some configuration options. These can be set by adding a config f
 - `types` (Array[String], default: []) – Set which Schema Types the Migration Action should be enabled in.
 - `filter` (String, default: undefined) - Set a predicate for documents when gathering dependencies.
 - `follow` (("inbound" | "outbound")[], default: []) – Add buttons to allow the user to begin with just the existing document or first fetch all inbound references.
+- `referenceMaxDepth` (Number, default: undefined) - The level of documents deep to follow, `0` represents the current document only. Must be a positive number. This is useful for when when gathering references returns a large number of references or when you want to be a bit more intentional about the which reference you gather.
+- `referenceMaxDepthAssetsOnly`: (boolean) - If true, only gather image and file assests. The 'referenceMaxDepth' option must be set for this to work.
 
 #### Action Options
 

--- a/src/helpers/getDocumentsInArray.ts
+++ b/src/helpers/getDocumentsInArray.ts
@@ -10,10 +10,21 @@ type OptionsBag = {
   projection?: string
 }
 
+const isAsset = (doc: SanityDocument) =>
+  doc._type === 'sanity.imageAsset' || doc._type === 'sanity.fileAsset'
+
+const returnOnlyAssets = (references: SanityDocument[]) =>
+  references.filter((item) => isAsset(item))
+
 // Recursively fetch Documents from an array of _id's and their references
 // Heavy use of Set is to avoid recursively querying for id's already in the payload
-export async function getDocumentsInArray(options: OptionsBag): Promise<SanityDocument[]> {
+
+export async function getDocumentsInArray(
+  options: OptionsBag,
+  recurrsionDepth: number = 0
+): Promise<SanityDocument[]> {
   const {fetchIds, client, pluginConfig, currentIds, projection} = options
+  const {referenceMaxDepth, referenceMaxDepthAssetsOnly} = pluginConfig
   const collection: SanityDocument[] = []
 
   // Find initial docs
@@ -56,15 +67,51 @@ export async function getDocumentsInArray(options: OptionsBag): Promise<SanityDo
 
           if (newReferenceIds.size) {
             // Recursive query for new documents
-            const referenceDocs = await getDocumentsInArray({
-              fetchIds: Array.from(newReferenceIds),
-              currentIds: localCurrentIds,
-              client,
-              pluginConfig,
-            })
 
-            if (referenceDocs?.length) {
-              collection.push(...referenceDocs)
+            // If the referenceMaxDepth is set, enter here for recursion and the option to only return assets
+            if (typeof referenceMaxDepth === 'number' && referenceMaxDepth >= 0) {
+              recurrsionDepth++
+
+              const referenceDocs = await getDocumentsInArray(
+                {
+                  fetchIds: Array.from(newReferenceIds),
+                  currentIds: localCurrentIds,
+                  client,
+                  pluginConfig,
+                },
+                recurrsionDepth
+              )
+
+              // I know this is a bit messy... but I hit the max nesting eslint limit
+              if (
+                // // If we are at the max depth and referenceMaxDepthAssetsOnly is falsy
+                referenceDocs?.length &&
+                recurrsionDepth === referenceMaxDepth + 1 &&
+                !referenceMaxDepthAssetsOnly
+              ) {
+                collection.push(...referenceDocs)
+              } else if (
+                // // If we are at the max depth and referenceMaxDepthAssetsOnly is truthy
+                referenceDocs?.length &&
+                recurrsionDepth === referenceMaxDepth + 1 &&
+                referenceMaxDepthAssetsOnly
+              ) {
+                collection.push(...returnOnlyAssets(referenceDocs))
+              } else if (referenceDocs?.length && recurrsionDepth < referenceMaxDepth + 1) {
+                // // If we are not at the max depth
+                collection.push(...referenceDocs)
+              }
+            } else {
+              const referenceDocs = await getDocumentsInArray({
+                fetchIds: Array.from(newReferenceIds),
+                currentIds: localCurrentIds,
+                client,
+                pluginConfig,
+              })
+
+              if (referenceDocs?.length) {
+                collection.push(...referenceDocs)
+              }
             }
           }
         }

--- a/src/helpers/getDocumentsInArray.ts
+++ b/src/helpers/getDocumentsInArray.ts
@@ -24,7 +24,7 @@ export async function getDocumentsInArray(
   recurrsionDepth: number = 0
 ): Promise<SanityDocument[]> {
   const {fetchIds, client, pluginConfig, currentIds, projection} = options
-  const {referenceMaxDepth, referenceMaxDepthAssetsOnly} = pluginConfig
+  const {reference} = pluginConfig
   const collection: SanityDocument[] = []
 
   // Find initial docs
@@ -69,7 +69,7 @@ export async function getDocumentsInArray(
             // Recursive query for new documents
 
             // If the referenceMaxDepth is set, enter here for recursion and the option to only return assets
-            if (typeof referenceMaxDepth === 'number' && referenceMaxDepth >= 0) {
+            if (typeof reference?.maxDepth === 'number' && reference?.maxDepth >= 0) {
               recurrsionDepth++
 
               const referenceDocs = await getDocumentsInArray(
@@ -86,18 +86,18 @@ export async function getDocumentsInArray(
               if (
                 // // If we are at the max depth and referenceMaxDepthAssetsOnly is falsy
                 referenceDocs?.length &&
-                recurrsionDepth === referenceMaxDepth + 1 &&
-                !referenceMaxDepthAssetsOnly
+                recurrsionDepth === reference.maxDepth + 1 &&
+                !reference?.assetsOnly
               ) {
                 collection.push(...referenceDocs)
               } else if (
                 // // If we are at the max depth and referenceMaxDepthAssetsOnly is truthy
                 referenceDocs?.length &&
-                recurrsionDepth === referenceMaxDepth + 1 &&
-                referenceMaxDepthAssetsOnly
+                recurrsionDepth === reference.maxDepth + 1 &&
+                reference?.assetsOnly
               ) {
                 collection.push(...returnOnlyAssets(referenceDocs))
-              } else if (referenceDocs?.length && recurrsionDepth < referenceMaxDepth + 1) {
+              } else if (referenceDocs?.length && recurrsionDepth < reference.maxDepth + 1) {
                 // // If we are not at the max depth
                 collection.push(...referenceDocs)
               }

--- a/src/helpers/getDocumentsInArray.ts
+++ b/src/helpers/getDocumentsInArray.ts
@@ -68,7 +68,7 @@ export async function getDocumentsInArray(
           if (newReferenceIds.size) {
             // Recursive query for new documents
 
-            // If the referenceMaxDepth is set, enter here for recursion and the option to only return assets
+            // If the reference?.maxDepth is set, enter here for recursion and the option to only return assets
             if (typeof reference?.maxDepth === 'number' && reference?.maxDepth >= 0) {
               recurrsionDepth++
 
@@ -84,14 +84,14 @@ export async function getDocumentsInArray(
 
               // I know this is a bit messy... but I hit the max nesting eslint limit
               if (
-                // // If we are at the max depth and referenceMaxDepthAssetsOnly is falsy
+                // // If we are at the max depth and reference?.assetsOnly is falsy
                 referenceDocs?.length &&
                 recurrsionDepth === reference.maxDepth + 1 &&
                 !reference?.assetsOnly
               ) {
                 collection.push(...referenceDocs)
               } else if (
-                // // If we are at the max depth and referenceMaxDepthAssetsOnly is truthy
+                // // If we are at the max depth and reference?.assetsOnly is truthy
                 referenceDocs?.length &&
                 recurrsionDepth === reference.maxDepth + 1 &&
                 reference?.assetsOnly

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,15 @@
 import {SanityDocument} from 'sanity'
 
 /**
+ * Reference object
+ * @public
+ */
+export type reference = {
+  maxDepth: number // Number of documents deep to follow
+  assetsOnly?: boolean // If true, only gather image and file assests
+}
+
+/**
  * Plugin configuration
  * @public
  */
@@ -9,8 +18,7 @@ export interface PluginConfig {
   types?: string[]
   filter?: string
   follow?: ('inbound' | 'outbound')[]
-  referenceMaxDepth?: number
-  referenceMaxDepthAssetsOnly?: boolean
+  reference?: reference
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,8 @@ export interface PluginConfig {
   types?: string[]
   filter?: string
   follow?: ('inbound' | 'outbound')[]
+  referenceMaxDepth?: number
+  referenceMaxDepthAssetsOnly?: boolean
 }
 
 /**


### PR DESCRIPTION
The purpose of the pull request this pull request is to add a configuration options for surrounding "Gathering References".  Currently, when you go to start the process of duplicating a document to a new dataset you are presented with the option to "Gather References".  This is done by gathering a list of all reference on a document, and then looping over each of those documents to gather a list of references they each have, and so until you run out of references.

This process generally works well and you never end up with the scenario of having a non-existent reference, which would break the import.  But in some cases you end up with a very high number of references gathered.  That is the situation this feature addition aims to solve.

I've added a new `reference` object to the options.  This includes two properties: a required field for `maxDepth` (number) that sets how many documents deep the reference gathering operation is performed.  A second property called `assetsOnly` (boolean) will only only gather image and file references in the final check for references at the maxDepth.  My thought here is that when grabbing the final round of references, you might want to have a clean break and just grab the asset references since assets _usually_ wont have additional references attached to them.

I'm proposing this addition as a tagged release so we can get some testing and feedback on it.
