### PR TITLE
feat: add migration filters to config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The plugin has some configuration options. These can be set by adding a config f
       tool: true,
       filter: '_type != "product"',
       follow: []
+      migrationFilters: []
     })
   ]
  })
@@ -78,6 +79,7 @@ The plugin has some configuration options. These can be set by adding a config f
 - `types` (Array[String], default: []) – Set which Schema Types the Migration Action should be enabled in.
 - `filter` (String, default: undefined) - Set a predicate for documents when gathering dependencies.
 - `follow` (("inbound" | "outbound")[], default: []) – Add buttons to allow the user to begin with just the existing document or first fetch all inbound references.
+- `migrationFilters` (Array[{ sourceDataset: string, targets: Array[{ projectId?: string; dataset: string }]], default: []) – Set which Datasets and Projects are allowed as destinations for Migrations. If no targets for a dataset is provided, all Workspaces are allowed as targets.
 
 #### Action Options
 
@@ -145,7 +147,6 @@ If you want to duplicate data across different projects, you need to enable CORS
 ## Future feature ideas
 
 - Save predefined GROQ queries in the Tool to make bulk repeated Migrations simpler
-- Config options for allowed migrations (eg Dev -> Staging but not Dev -> Live)
 - Config options for permissions/user role checks
 
 ## License

--- a/src/components/Duplicator.tsx
+++ b/src/components/Duplicator.tsx
@@ -92,8 +92,9 @@ export default function Duplicator(props: DuplicatorProps) {
         (m) =>
           m.dataset === workspace.dataset &&
           // If project ID is configured for target, check that filter matches.
-          m.projectId &&
-          m.projectId === workspace.projectId
+          ((m.projectId && m.projectId === workspace.projectId) ||
+            // If project ID is not configured for target, check that source and target are in the same project.
+            workspace.projectId === sourceProjectId)
       )
     return {
       ...workspace,

--- a/src/components/Duplicator.tsx
+++ b/src/components/Duplicator.tsx
@@ -78,10 +78,32 @@ export default function Duplicator(props: DuplicatorProps) {
   // Create list of dataset options
   // and set initial value of dropdown
   const workspaces = useWorkspaces()
-  const workspacesOptions: WorkspaceOption[] = workspaces.map((workspace) => ({
-    ...workspace,
-    disabled: workspace.dataset === originClient.config().dataset,
-  }))
+  const {projectId: sourceProjectId, dataset: sourceDataset} = originClient.config()
+  const workspacesOptions: WorkspaceOption[] = workspaces.map((workspace) => {
+    const migrationFilter = pluginConfig.migrationFilters?.find(
+      (m) => m.sourceDataset === sourceDataset
+    )
+    const isSourceWorkspace =
+      workspace.projectId === sourceProjectId && workspace.dataset === sourceDataset
+    const isAllowedMigration =
+      // If no migrationFilter is configured for this dataset, allow all migration targets.
+      !migrationFilter ||
+      migrationFilter.targets.find(
+        (m) =>
+          m.dataset === workspace.dataset &&
+          // If project ID is configured for target, check that filter matches.
+          m.projectId &&
+          m.projectId === workspace.projectId
+      )
+    return {
+      ...workspace,
+      disabled: isSourceWorkspace || !isAllowedMigration,
+    }
+  })
+
+  const currentWorkspace = workspacesOptions.find(
+    (workspace) => workspace.projectId === sourceProjectId && workspace.dataset === sourceDataset
+  )
 
   const [destination, setDestination] = useState<WorkspaceOption | null>(
     workspaces.length ? workspacesOptions.find((space) => !space.disabled) ?? null : null
@@ -434,7 +456,7 @@ export default function Duplicator(props: DuplicatorProps) {
               <Flex gap={3}>
                 <Stack style={{flex: 1}} space={3}>
                   <Label>Duplicate from</Label>
-                  <Select readOnly value={workspacesOptions.find((space) => space.disabled)?.name}>
+                  <Select readOnly value={currentWorkspace?.name}>
                     {workspacesOptions
                       .filter((space) => space.disabled)
                       .map((space) => (
@@ -457,7 +479,10 @@ export default function Duplicator(props: DuplicatorProps) {
                       <option key={space.name} value={space.name} disabled={space.disabled}>
                         {space.title ?? space.name}
                         {hasMultipleProjectIds ? ` (${space.projectId})` : ``}
-                        {space.disabled ? ` (Current)` : ``}
+                        {currentWorkspace?.name === space.name &&
+                        currentWorkspace.projectId === space.projectId
+                          ? ` (Current)`
+                          : ``}
                       </option>
                     ))}
                   </Select>

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -7,4 +7,5 @@ export const DEFAULT_CONFIG: PluginConfig = {
   types: [],
   filter: '',
   follow: ['outbound'],
+  migrationFilters: [],
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,10 @@
 import {SanityDocument} from 'sanity'
 
+type MigrationFilter = {
+  sourceDataset: string
+  targets: {projectId?: string; dataset: string}[]
+}
+
 /**
  * Plugin configuration
  * @public
@@ -9,6 +14,7 @@ export interface PluginConfig {
   types?: string[]
   filter?: string
   follow?: ('inbound' | 'outbound')[]
+  migrationFilters?: MigrationFilter[]
 }
 
 /**


### PR DESCRIPTION
In order to prevent accidental duplication of data from one dataset to an incorrect dataset (e.g. by fat fingering, or selecting the wrong dataset by mistake), this new configuration option is intended to reduce the options provided in the UI only to those that are desired/expected targets of duplication from a dataset.

If this filter is not provided, all datasets are valid targets - this is the existing behavior as it exists today.

(note: this is a duplicate of #52 - I wished to have colleague on my team preemptively review before opening up a PR against this repo)