### PR TITLE
fix: handle reference errors during document duplication process

### DIFF
--- a/src/components/Duplicator.tsx
+++ b/src/components/Duplicator.tsx
@@ -7,6 +7,7 @@ import {
   useWorkspaces,
   WorkspaceSummary,
   SanityDocument,
+  SanityClient,
 } from 'sanity'
 // @ts-ignore
 import mapLimit from 'async/mapLimit'
@@ -39,6 +40,109 @@ import SelectButtons from './SelectButtons'
 import StatusBadge, {MessageTypes} from './StatusBadge'
 import Feedback from './Feedback'
 import {PluginConfig} from '../types'
+
+type SetMessage = (msg: {text: string; tone: CardTone}) => void
+
+async function commitOneByOne(
+  docs: SanityDocument[],
+  client: SanityClient,
+  setMessage: SetMessage,
+  onSuccess: () => void
+): Promise<void> {
+  let successCount = 0
+  let failCount = 0
+  for (const doc of docs) {
+    try {
+      const tx = client.transaction()
+      tx.createOrReplace(doc)
+      // eslint-disable-next-line no-await-in-loop
+      await tx.commit()
+      successCount++
+    } catch (_e) {
+      failCount++
+    }
+  }
+  if (failCount === 0) {
+    setMessage({tone: 'positive', text: 'Duplication complete!'})
+    onSuccess()
+  } else {
+    setMessage({
+      tone: 'critical',
+      text: `Duplication finished with ${failCount} error(s). ${successCount} document(s) duplicated successfully.`,
+    })
+    if (successCount > 0) onSuccess()
+  }
+}
+
+type ReferenceErrorOptions = {
+  err: any
+  transactionDocs: SanityDocument[]
+  originClient: SanityClient
+  destinationClient: SanityClient
+  setMessage: SetMessage
+  onSuccess: () => void
+}
+
+async function handleReferenceError(options: ReferenceErrorOptions): Promise<void> {
+  const {err, transactionDocs, originClient, destinationClient, setMessage, onSuccess} = options
+  const description: string = err?.details?.description ?? err?.message ?? ''
+
+  // Extract missing document IDs from error details or description string
+  const missingIds: string[] = []
+
+  if (Array.isArray(err?.details?.items)) {
+    for (const item of err.details.items) {
+      const refId = item?.error?.referencedId ?? item?.error?.referenceId
+      if (refId && !missingIds.includes(refId)) missingIds.push(refId)
+    }
+  }
+
+  const refRegex = /references non-existent document [`'"]?([^`'"\s)]+)[`'"]?/gi
+  let match
+  // eslint-disable-next-line no-cond-assign
+  while ((match = refRegex.exec(description)) !== null) {
+    if (!missingIds.includes(match[1])) missingIds.push(match[1])
+  }
+
+  if (!missingIds.length) {
+    // IDs not parseable – fall back to one-by-one
+    setMessage({tone: 'default', text: 'Retrying documents one by one...'})
+    await commitOneByOne(transactionDocs, destinationClient, setMessage, onSuccess)
+    return
+  }
+
+  setMessage({
+    tone: 'default',
+    text: `Fetching ${missingIds.length} missing referenced document(s) and retrying...`,
+  })
+
+  let missingDocs: SanityDocument[] = []
+  try {
+    missingDocs = await originClient.fetch(`*[_id in $ids]`, {ids: missingIds})
+  } catch (fetchErr: any) {
+    setMessage({tone: 'critical', text: description || (fetchErr as Error)?.message})
+    return
+  }
+
+  const allDocs = [...transactionDocs, ...missingDocs]
+
+  if (missingDocs.length > 0) {
+    setMessage({tone: 'default', text: `Duplicating ${missingDocs.length} missing document(s)...`})
+    const retryTx = destinationClient.transaction()
+    allDocs.forEach((doc) => retryTx.createOrReplace(doc))
+    try {
+      await retryTx.commit()
+      setMessage({tone: 'positive', text: 'Duplication complete!'})
+      onSuccess()
+    } catch (_retryErr) {
+      setMessage({tone: 'default', text: 'Retrying documents one by one...'})
+      await commitOneByOne(allDocs, destinationClient, setMessage, onSuccess)
+    }
+  } else {
+    setMessage({tone: 'default', text: 'Retrying documents one by one...'})
+    await commitOneByOne(transactionDocs, destinationClient, setMessage, onSuccess)
+  }
+}
 
 export type DuplicatorProps = {
   docs: SanityDocument[]
@@ -339,16 +443,29 @@ export default function Duplicator(props: DuplicatorProps) {
       transaction.createOrReplace(doc)
     })
 
-    await transaction
-      .commit()
-      .then((res) => {
-        setMessage({tone: 'positive', text: 'Duplication complete!'})
+    try {
+      await transaction.commit()
+      setMessage({tone: 'positive', text: 'Duplication complete!'})
+      updatePayloadStatuses()
+    } catch (err: any) {
+      const description: string = err?.details?.description ?? err?.message ?? ''
+      const isReferenceError =
+        description.toLowerCase().includes('references non-existent document') ||
+        description.toLowerCase().includes('reference non-existent')
 
-        updatePayloadStatuses()
-      })
-      .catch((err) => {
-        setMessage({tone: 'critical', text: err.details.description})
-      })
+      if (isReferenceError) {
+        await handleReferenceError({
+          err,
+          transactionDocs: transactionDocsMapped,
+          originClient,
+          destinationClient,
+          setMessage,
+          onSuccess: updatePayloadStatuses,
+        })
+      } else {
+        setMessage({tone: 'critical', text: description || 'Duplication failed'})
+      }
+    }
 
     setIsDuplicating(false)
     setProgress([0, 0])


### PR DESCRIPTION
This pull request introduces improved error handling and robustness to the document duplication process in the `Duplicator` component. The main focus is on gracefully handling reference errors that occur when duplicating documents with missing references, ensuring that the duplication process is retried intelligently and users are kept informed of progress and errors.

**Enhanced duplication error handling:**

* Added the `handleReferenceError` function to detect missing referenced documents, fetch them from the origin client, and retry duplication, falling back to one-by-one commits if necessary. This ensures more reliable duplication when references are missing.
* Updated the main duplication logic in the `Duplicator` component to catch errors during transaction commits, invoke `handleReferenceError` for reference-related errors, and provide improved user feedback for other errors.
* Introduced the `commitOneByOne` function to commit documents individually when batch duplication fails, increasing the likelihood of successful duplication and providing granular error reporting.

**Codebase improvements:**

* Added `SanityClient` to imports and defined the `SetMessage` type for clearer typing and maintainability. [[1]](diffhunk://#diff-49e8b2df317058157e5430abf9234280178adfbdaaccf26b1ac0c98c052682daR10) [[2]](diffhunk://#diff-49e8b2df317058157e5430abf9234280178adfbdaaccf26b1ac0c98c052682daR44-R146)### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
IS PENDING
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
